### PR TITLE
proposal: basenames as new account type

### DIFF
--- a/src/app/components/icons/BasenamesIcon.tsx
+++ b/src/app/components/icons/BasenamesIcon.tsx
@@ -1,0 +1,14 @@
+import { Icon, type IconProps } from ':/app/components/Icon';
+
+export function BasenamesIcon(props: Omit<IconProps, 'children'>) {
+  return (
+    <Icon viewBox="0 0 111 111" {...props}>
+      <svg>
+        <path
+          d="M54.921 110.034C85.359 110.034 110.034 85.402 110.034 55.017C110.034 24.6319 85.359 0 54.921 0C26.0432 0 2.35281 22.1714 0 50.3923H72.8467V59.6416H3.9565e-07C2.35281 87.8625 26.0432 110.034 54.921 110.034Z"
+          fill="currentColor"
+        />
+      </svg>
+    </Icon>
+  );
+}

--- a/src/app/components/icons/BasenamesIcon.tsx
+++ b/src/app/components/icons/BasenamesIcon.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from ':/app/components/Icon';
 
-export function BasenamesIcon(props: Omit<IconProps, 'children'>) {
+export function BasenameIcon(props: Omit<IconProps, 'children'>) {
   return (
     <Icon viewBox="0 0 111 111" {...props}>
       <svg>

--- a/src/constants/channelTypes.ts
+++ b/src/constants/channelTypes.ts
@@ -1,8 +1,8 @@
 export const CHANNEL_TYPES = [
   'apple',
+  'basename',
   'behance',
   'bluesky',
-  'basenames',
   'calendar',
   'colinks',
   'custom',
@@ -112,9 +112,9 @@ export const VERIFIABLE_CHANNEL_TYPES = [
 export type VerifiableChannelType = (typeof VERIFIABLE_CHANNEL_TYPES)[number];
 
 export const CHANNEL_TYPE_PREFIXES: Partial<Record<ChannelType, string>> = {
+  basename: 'base.org/name/',
   behance: 'behance.net/',
   bluesky: 'bsky.app/profile/',
-  basenames: 'app.ens.domains/',
   colinks: 'colinks.coordinape.com/',
   daimo: 'daimo.com/l/account/',
   deca: 'deca.art/',

--- a/src/constants/channelTypes.ts
+++ b/src/constants/channelTypes.ts
@@ -2,6 +2,7 @@ export const CHANNEL_TYPES = [
   'apple',
   'behance',
   'bluesky',
+  'basenames',
   'calendar',
   'colinks',
   'custom',
@@ -113,6 +114,7 @@ export type VerifiableChannelType = (typeof VERIFIABLE_CHANNEL_TYPES)[number];
 export const CHANNEL_TYPE_PREFIXES: Partial<Record<ChannelType, string>> = {
   behance: 'behance.net/',
   bluesky: 'bsky.app/profile/',
+  basenames: 'app.ens.domains/',
   colinks: 'colinks.coordinape.com/',
   daimo: 'daimo.com/l/account/',
   deca: 'deca.art/',


### PR DESCRIPTION
Entry for 50 USDC bounty on BountyCaster "Open a PR against the Alloy repo to add base name account support with icon".

What was done ?

Basenames is a subdomain of the ethereum ens protocol and no longer a standalone service, I added basenames following the readme guide. The proposed prefix was the ens prefix and icon svg, base's svg.